### PR TITLE
AnalogSimPinFd to simulate analog input or output.

### DIFF
--- a/analogio.cpp
+++ b/analogio.cpp
@@ -130,6 +130,10 @@ AnalogIo::AnalogIo(const char* aPinSpec, bool aOutput, double aInitialValue)
     }
     ioPin = AnalogIOPinPtr(new PWMPin(chipNumber, channelNumber, inverted, aInitialValue, periodNs));
   }
+  if (busName=="sim") {
+    // analog I/O from simulated fd
+    ioPin = AnalogIOPinPtr(new AnalogSimPinFd(pinName.c_str(), output, aInitialValue));
+  }
   else {
     // all other/unknown bus names default to simulated pin
     ioPin = AnalogIOPinPtr(new AnalogSimPin(pinspec.c_str(), output, aInitialValue));

--- a/iopin.hpp
+++ b/iopin.hpp
@@ -93,8 +93,8 @@ namespace p44 {
 
   };
   typedef boost::intrusive_ptr<IOPin> IOPinPtr;
-  
-  
+
+
 
   /// simulated digital I/O pin
   class SimPin : public IOPin
@@ -287,10 +287,33 @@ namespace p44 {
     string valueSetCommand(double aValue);
     void applyValue(double aValue);
     void valueUpdated(ErrorPtr aError, const string &aOutputString);
-    
+
   };
 
   #endif // !DISABLE_SYSTEMCMDIO
+
+  /// simulated I/O pin via file device
+  class AnalogSimPinFd : public AnalogIOPin
+  {
+    typedef AnalogIOPin inherited;
+
+    bool output;
+    string name;
+    int fd;
+    double pinValue;
+
+  public:
+    // create a simulated pin (using console I/O)
+    AnalogSimPinFd(const char *aName, bool aOutput, double aInitialValue);
+
+    /// get value of pin
+    /// @return current value (from actual pin for inputs, from last set state for outputs)
+    virtual double getValue();
+
+    /// set value of pin (NOP for inputs)
+    /// @param aValue new value to set output to
+    virtual void setValue(double aValue);
+  };
 
 
 } // namespace


### PR DESCRIPTION
Devices like sim./tmp/simpin could be used to simulate analog input or output.